### PR TITLE
Remove header section and restore old version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,11 +29,6 @@
             </svg>
         </button>
 
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -104,27 +104,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
     flex: 1;
@@ -785,15 +764,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Fixes #2

Removed the newly added header elements while preserving the theme toggle functionality:

- Removed "Course Materials Assistant" header
- Removed "Ask questions..." subtitle
- Removed all header-related CSS styling
- Theme toggle button remains functional

Generated with [Claude Code](https://claude.ai/code)